### PR TITLE
client integration: svelte-i18n-integration

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -1,0 +1,9 @@
+const clients = [['svelte-i18n', () => import('./svelte-i18n')]]
+
+const clientOptions = (client, defaultLocale, { config, options }) => Object.assign(client.processConfig(config, defaultLocale), options)
+
+const fillClientDictionary = (client, data) => data.forEach(d => client.addEntry(d.locale, d.content))
+
+// Init Should be call during render and in client side
+
+module.exports = { clientOptions, fillClientDictionary, clients }

--- a/clients/svelte-i18n.js
+++ b/clients/svelte-i18n.js
@@ -1,0 +1,35 @@
+const { addMessages, init, getLocaleFromNavigator } = require('svelte-i18n')
+
+const defaultConfig = {
+  initialLocale: 'default',
+  fallback: 'default'
+}
+
+const addEntry = addMessages
+
+const processInitialLocale = (configInitialLocale, defaultLocale) => {
+  // Add others
+  switch (configInitialLocale) {
+    case 'navigator':
+      return () => getLocaleFromNavigator()
+    case 'default':
+      return defaultLocale
+    default:
+      return configInitialLocale
+  }
+}
+
+const processFallbackLocale = (configFallbackLocale, defaultLocale) => {
+  if (configFallbackLocale === 'default') return defaultLocale
+  return configFallbackLocale
+}
+
+const processConfig = (config, defaultLocale) => {
+  const options = Object.assign({}, defaultConfig, config)
+  return {
+    initialLocale: processInitialLocale(options.initialLocale, defaultLocale),
+    fallbackLocale: processFallbackLocale(options.fallbackLocale, defaultLocale)
+  }
+}
+
+module.exports = { addEntry, init, processConfig }

--- a/helpers.js
+++ b/helpers.js
@@ -1,3 +1,9 @@
+const { fillEntry } = require('./utils')
+
+//
+// Permalinks
+//
+
 // Fix permalink helpers with access to helpers
 const i18nPermalinks = (routes, settings, helpers) =>
   Object.keys(routes).reduce((out, cv) => {
@@ -18,12 +24,17 @@ const generatePermalink = ({ prefix, prefixDefault }, locales, defaultLocale) =>
   return (permalink, locale) => (locale === defaultLocale ? permalink : createi18nPermalink(permalink, locale))
 }
 
+//
+// Helpers
+//
+
 const i18nHelpers = (helpers, settings, routes, plugin) => {
   return {
     generateRequests: (reqs) => {
       const requests = []
       reqs.forEach((req) => {
         plugin.config.locales.all.forEach((locale) => {
+          // TODO: check this out
           // if (plugin.config.excludeLocales.includes(locale.code)) return;
           requests.push(Object.assign({}, req, { locale: locale.code }))
         })
@@ -46,6 +57,11 @@ const i18nHelpers = (helpers, settings, routes, plugin) => {
           permalink: origin + plugin.dictionaries.requests[locale][route][slug].permalink
         }
       })
+    },
+    addData: (request, data) => {
+      const newData = {}
+      newData[request.slug] = data
+      fillEntry(plugin.dictionaries.data, request.lang, request.route, newData)
     },
     dictionaries: plugin.dictionaries,
     locales: () => plugin.locales

--- a/index.js
+++ b/index.js
@@ -34,6 +34,14 @@ const plugin = {
     seo: {
       hreflang: true,
       lang: true
+    },
+    client: {
+      name: 'svelte-i18n',
+      config: {
+        initialLocale: 'navigator',
+        fallback: 'default'
+      },
+      options: {}
     }
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -15,6 +15,14 @@ const makeHreflang = (locale, url) => {
 // Dictionnaries
 //
 
+const fillEntry = (dictionary, locale, key, entry) => {
+  if (dictionary[locale][key] === undefined) {
+    dictionary[locale][key] = entry
+  } else {
+    Object.assign(dictionary[locale][key], entry)
+  }
+}
+
 const fillDictionary = async (dictionary, allRequests, getExtraData) => {
   const getData = getExtraData
     ? async (request) => {
@@ -35,10 +43,12 @@ const fillDictionary = async (dictionary, allRequests, getExtraData) => {
     dictionary[request.locale][request.route][request.slug] = data
   })
 }
+
 //
 // Set permalinks to request, based on elderjs code
 // Basically a copy of src/Elder.ts way, but with a refacto to match my taste
 // Need createReadOnlyProxy implementation
+//
 
 const createReadOnlyProxy = (obj, objName, location) => {
   try {
@@ -75,4 +85,4 @@ const getPermalink = async (request, { routes, settings, helpers }) => {
   }
 }
 
-module.exports = { fillDictionary, fillDictionaryWithCopy, makeHreflang, getPermalink }
+module.exports = { fillDictionary, fillEntry, makeHreflang, getPermalink }


### PR DESCRIPTION
- [x] `addData` helper, to select which data  to send to svelte-i18n
- [x] fill dictionary data
- [x] basic i18n client side support
- [x] fill svelte-i18n dictionnary
- [x] ability to manually override options for svelte-i18n
- [x] init svelte-i18n server (during generation)
- [ ] init svelte-i18n client side
- [ ] hydratation support
- [x] set `initialeLocale` & `fallbackLocale` based on elderjs-plugin-i18n settings (or manually)
- [x] helper for initialeLocale based on navigator
- [ ] helper for initialeLocale from other function (with parameter) from svelte-i18n
- [ ] set routes corresponding locale
- [ ] update documentation

Optional:
- [ ] add options to add all data to  svelte-i18n
- [ ] add documentation to add other clients
- [ ] add external other clients